### PR TITLE
opt and authenticator code validation checks for non-ascii characters

### DIFF
--- a/sso_frontend/login_frontend/models.py
+++ b/sso_frontend/login_frontend/models.py
@@ -431,8 +431,9 @@ class Browser(models.Model):
     @sd.timer("login_frontend.models.Browser.validate_sms")
     def validate_sms(self, otp):
         """ Returns tuple, (status, message). Message is optional. """
-        if not self.is_ascii(otp):
-            return (False, "Non-ascii characters in the sms code")
+        for c in otp:
+            if c not in set(string.printable):
+                return (False, "Non-ascii characters in the sms code")
         if not self.user:
             # TODO: this is invalid state and should never happen. Handle this properly.
             return (False, None)
@@ -979,8 +980,9 @@ class User(models.Model):
           describing the problem.
         """
 
-        if not self.is_ascii(code):
-            return (False, "Non-ascii characters in the authenticator code")
+        for c in code:
+            if c not in set(string.printable):
+                return (False, "Non-ascii characters in the authenticator code")
 
         if not self.strong_authenticator_secret:
             return (False, "Authenticator is not configured")
@@ -1029,12 +1031,6 @@ class User(models.Model):
                     return (False, message)
 
         return (False, "Incorrect OTP code.")
-    
-    def is_ascii(self, code):
-        for c in code:
-            if c not in set(string.printable):
-                return False
-        return True
 
     @sd.timer("login_frontend.models.User.refresh_strong")
     def refresh_strong(self, email, phone1, phone2, **kwargs):


### PR DESCRIPTION
When entering 2-factor or authenticator code on Safari, user can accidentally enter non-ascii characters, which cause a server error. Other browsers prevent sending non-ascii characters in the client-side javascript.  #4 